### PR TITLE
feat: add `createJson` and `contentsJson`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,3 +65,4 @@ export function fileSystem(options?: { basePath?: string | URL; autoClean?: bool
 
 export type { EntryInfo } from 'readdirp'
 export type { WriteFileOptions } from 'fs-extra'
+export type { FileSystem } from './src/file_system'

--- a/src/file_system.ts
+++ b/src/file_system.ts
@@ -104,4 +104,18 @@ export class FileSystem {
       ? readDir.promise(this.#makePath(dirPath), { type: 'files' })
       : readDir.promise(this.basePath, { type: 'files' })
   }
+
+  /**
+   * Create a json file
+   */
+  async createJson(filePath: string, contents: any, options?: fs.WriteFileOptions) {
+    return this.adapter.writeJson(this.#makePath(filePath), contents, options)
+  }
+
+  /**
+   * Read and parse a json file
+   */
+  async contentsJson(filePath: string) {
+    return this.adapter.readJson(this.#makePath(filePath))
+  }
 }

--- a/src/file_system.ts
+++ b/src/file_system.ts
@@ -108,8 +108,8 @@ export class FileSystem {
   /**
    * Create a json file
    */
-  async createJson(filePath: string, contents: any, options?: fs.WriteFileOptions) {
-    return this.adapter.writeJson(this.#makePath(filePath), contents, options)
+  async createJson(filePath: string, contents: any, options?: fs.JsonOutputOptions) {
+    return this.adapter.outputJSON(this.#makePath(filePath), contents, options)
   }
 
   /**


### PR DESCRIPTION
Added `createJson` and `contentsJson` methods which are pretty useful when dealing with json files

Also re-exported FileSystem type from root because the type is not exposed which is quite annoying for the creation of small helpers in our tests. For example I wanted to make a helper :

```ts
setupHotfile(fs: FileSystem) {
  await fs.create('public/assets/hot.json, 'foo')
}

test('my test', ({ assert, fs }) => {
  await setupHotfile(fs)
})
```

But not possible because the FileSystem type is not exposed. So we have to replace it by `any`

